### PR TITLE
add python-aiohttp-cors dependency

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -14,7 +14,7 @@ makedepends=('python-setuptools')
 # NB: this package will install additional python packages in /var/lib/hass/lib depending on components present in the configuration files.
 depends=('python' 'python-pip' 'python-requests>=2.14.2' 'python-yaml' 'python-pytz>=2017.2'
          'python-vincenty' 'python-voluptuous>=0.9.3' 'python-netifaces'
-         'python-webcolors' 'python-async-timeout>=1.3.0' 'python-aiohttp>=2.2.5'
+         'python-webcolors' 'python-async-timeout>=1.3.0' 'python-aiohttp>=2.2.5' 'python-aiohttp-cors>=0.5.3'
          'python-jinja>=2.9.5' 'python-yarl>=0.11.0' 'python-chardet>=3.0.4' 'python-astral')
 optdepends=('git: install component requirements from github'
             'net-tools: necessary for nmap discovery')


### PR DESCRIPTION
without python-aiohttp-cors it won't start:
2017-10-16 14:59:24 ERROR (MainThread) [homeassistant.setup] Error during setup of component http
Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/homeassistant/setup.py", line 191, in _async_setup_component
    result = yield from component.async_setup(hass, processed_config)
  File "/usr/lib/python3.6/asyncio/coroutines.py", line 210, in coro
    res = func(*args, **kw)
  File "/usr/lib/python3.6/site-packages/homeassistant/components/http/__init__.py", line 141, in async_setup
    is_ban_enabled=is_ban_enabled
  File "/usr/lib/python3.6/site-packages/homeassistant/components/http/__init__.py", line 184, in __init__
    import aiohttp_cors
ModuleNotFoundError: No module named 'aiohttp_cors'