### PR TITLE
Tried to fix for 0.64.0

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = home-assistant
 	pkgdesc = Open-source home automation platform running on Python 3
-	pkgver = 0.63.2
+	pkgver = 0.64.0
 	pkgrel = 2
 	url = https://home-assistant.io/
 	install = hass.install
@@ -13,27 +13,28 @@ pkgbase = home-assistant
 	depends = python-yaml
 	depends = python-pytz>=2017.2
 	depends = python-vincenty
-	depends = python-voluptuous>=0.9.3
+	depends = python-voluptuous>=0.11.1
 	depends = python-netifaces
 	depends = python-webcolors
 	depends = python-async-timeout>=2.0.0
-	depends = python-aiohttp
+	depends = python-aiohttp=2.3.10
 	depends = python-aiohttp-cors>=0.5.3
 	depends = python-jinja>=2.9.5
-	depends = python-yarl
+	depends = python-yarl>=1.1.0
 	depends = python-chardet>=3.0.4
-	depends = python-astral
+	depends = python-astral>=1.5
 	depends = python-certifi
 	depends = python-attrs
+	depends = python-multidict>=4.0
 	optdepends = git: install component requirements from github
 	optdepends = net-tools: necessary for nmap discovery
 	replaces = python-home-assistant
-	source = home-assistant-0.63.2.tar.gz::https://github.com/home-assistant/home-assistant/archive/0.63.2.tar.gz
+	source = home-assistant-0.64.0.tar.gz::https://github.com/home-assistant/home-assistant/archive/0.64.0.tar.gz
 	source = home-assistant.service
 	source = home-assistant.sysusers
 	source = home-assistant-tmpfile.conf
 	source = hass.install
-	sha512sums = 59d9dda2228b826795030d3b0db7e55b8d24664c3d39ec95ae83ccc72d2ca69f7059e8d2f096199ae450c0ac6f20f3de8242e99f308cead6686b39ab4cd6763b
+	sha512sums = 9a1b7f494897041e2361d4e56bd073c7b6b6120db408deaf0149f3cc72048f02b6e9e419d77de551c462d6c840c3111170a120dd50e1fe790110bcb2dd84c444
 	sha512sums = fe96bd3df3ba666fd9f127c466d1dd1dd7314db2e57826a2b319c8a0bfad7aedeac398e748f93c6ecd9c2247ebbae196b8b0e7263b8681e2b7aeab6a8bfeab80
 	sha512sums = 100665ac35370c3ccec65d73521568de21cebf9e46af364124778861c94e338e32ad9abb675d3917f97d351dd7867e3ab2e80c26616330ae7cf0d9dc3f13369b
 	sha512sums = 8babcf544c97ec5ad785014f0b0d5dca556a2f5157dadcbe83d49d4669b74f6349e274810ec9a028fcec208c6c8fbbe6b3899d2933b56163b9e506570879a3ad

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -4,7 +4,7 @@
 
 pkgname="home-assistant"
 pkgdesc='Open-source home automation platform running on Python 3'
-pkgver=0.63.2
+pkgver=0.64.0
 pkgrel=2
 url="https://home-assistant.io/"
 license=('APACHE')
@@ -13,9 +13,10 @@ replaces=('python-home-assistant')
 makedepends=('python-setuptools')
 # NB: this package will install additional python packages in /var/lib/hass/lib depending on components present in the configuration files.
 depends=('python' 'python-pip' 'python-requests>=2.14.2' 'python-yaml' 'python-pytz>=2017.2'
-         'python-vincenty' 'python-voluptuous>=0.9.3' 'python-netifaces'
-         'python-webcolors' 'python-async-timeout>=2.0.0' 'python-aiohttp' 'python-aiohttp-cors>=0.5.3'
-         'python-jinja>=2.9.5' 'python-yarl' 'python-chardet>=3.0.4' 'python-astral' 'python-certifi' 'python-attrs')
+         'python-vincenty' 'python-voluptuous>=0.11.1' 'python-netifaces'
+         'python-webcolors' 'python-async-timeout>=2.0.0' 'python-aiohttp=2.3.10' 'python-aiohttp-cors>=0.5.3'
+         'python-jinja>=2.9.5' 'python-yarl>=1.1.0' 'python-chardet>=3.0.4' 'python-astral>=1.5' 'python-certifi' 'python-attrs'
+         'python-multidict>=4.0')
 optdepends=('git: install component requirements from github'
             'net-tools: necessary for nmap discovery')
 source=("${pkgname}-${pkgver}.tar.gz::https://github.com/${pkgname}/${pkgname}/archive/${pkgver}.tar.gz"
@@ -23,7 +24,7 @@ source=("${pkgname}-${pkgver}.tar.gz::https://github.com/${pkgname}/${pkgname}/a
         "home-assistant.sysusers"
         "home-assistant-tmpfile.conf"
         "hass.install")
-sha512sums=('59d9dda2228b826795030d3b0db7e55b8d24664c3d39ec95ae83ccc72d2ca69f7059e8d2f096199ae450c0ac6f20f3de8242e99f308cead6686b39ab4cd6763b'
+sha512sums=('9a1b7f494897041e2361d4e56bd073c7b6b6120db408deaf0149f3cc72048f02b6e9e419d77de551c462d6c840c3111170a120dd50e1fe790110bcb2dd84c444'
             'fe96bd3df3ba666fd9f127c466d1dd1dd7314db2e57826a2b319c8a0bfad7aedeac398e748f93c6ecd9c2247ebbae196b8b0e7263b8681e2b7aeab6a8bfeab80'
             '100665ac35370c3ccec65d73521568de21cebf9e46af364124778861c94e338e32ad9abb675d3917f97d351dd7867e3ab2e80c26616330ae7cf0d9dc3f13369b'
             '8babcf544c97ec5ad785014f0b0d5dca556a2f5157dadcbe83d49d4669b74f6349e274810ec9a028fcec208c6c8fbbe6b3899d2933b56163b9e506570879a3ad'
@@ -39,12 +40,12 @@ prepare() {
   # typing package is a backport of standard library < 3.5
   replace 'typing>=3,<4' '' setup.py
 
-  replace 'aiohttp>=2.3.10' 'aiohttp>=2.3.9' setup.py
+  # Remving theese as they break 0.64 with yarl-1.10 and aiohttp-2.3.10
+  # replace 'aiohttp>=2.3.10' 'aiohttp>=2.3.9' setup.py
 
-
-  echo Patching for home-assistant/home-assistant#11906
-  sed -i 's/from yarl import unquote/from yarl import URL/' homeassistant/components/http/static.py
-  sed -i "s/unquote(request.match_info\['filename'\])/URL(request.match_info['filename'], encoded=True).path/" homeassistant/components/http/static.py
+  # echo Patching for home-assistant/home-assistant#11906
+  # sed -i 's/from yarl import unquote/from yarl import URL/' homeassistant/components/http/static.py
+  # sed -i "s/unquote(request.match_info\['filename'\])/URL(request.match_info['filename'], encoded=True).path/" homeassistant/components/http/static.py
 }
 
 replace() {


### PR DESCRIPTION
This aproach works for me, all the changes are needed:
 - Bump to 0.64.0
 - Remove the yarn patch
 - Update dependency versions
 - Fix aiohttp versio to 2.3.10

To install the needed aiohttp version i used arch archive ( https://archive.archlinux.org/packages/p/python-aiohttp/ ) 

I dunno how to add this as an explicit dependency, hope this helps somebody to solve this issue "more cleanly"